### PR TITLE
Use / as path sep even on Windows

### DIFF
--- a/pdf_compressor/main.py
+++ b/pdf_compressor/main.py
@@ -141,8 +141,9 @@ def main(argv: Sequence[str] = None) -> int:
         "non-empty suffix to append to the name of compressed files."
     )
 
-    pdfs = [file for file in args.filenames if file.lower().endswith(".pdf")]
-    not_pdfs = [file for file in args.filenames if not file.lower().endswith(".pdf")]
+    files = [f.replace("\\", "/") for f in args.filenames]
+    pdfs = [f for f in files if f.lower().endswith(".pdf")]
+    not_pdfs = [f for f in files if not f.lower().endswith(".pdf")]
 
     if args.on_bad_files == "error" and len(not_pdfs) > 0:
         raise TypeError(

--- a/pdf_compressor/utils.py
+++ b/pdf_compressor/utils.py
@@ -145,7 +145,7 @@ def del_or_keep_compressed(
         counter = f"\n{idx}: " if n_files > 1 else ""
 
         if diff / orig_size > min_size_reduction / 100:
-            pretty_path = relpath(orig_path, expanduser("~"))
+            pretty_path = relpath(orig_path)
             print(
                 f"{counter}'{pretty_path}' is now {si_fmt(compressed_size)}B, before "
                 f"{si_fmt(orig_size)}B ({si_fmt(diff)}B = {diff/orig_size:.1%} smaller)"

--- a/pdf_compressor/utils.py
+++ b/pdf_compressor/utils.py
@@ -164,7 +164,9 @@ def del_or_keep_compressed(
                 else:
                     print("Old file deleted.")
 
-                os.rename(compr_path, orig_path)
+                # better then os.rename() on Windows which errors if destination file
+                # path already exists
+                os.replace(compr_path, orig_path)
 
             elif suffix:
                 new_path = make_uniq_filename(orig_path, suffix)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -19,7 +19,7 @@ def test_main():
     try:
         os.chdir("./assets")
 
-        # include sep to test https://github.com/janosh/pdf-compressor/issues/9
+        # include path sep to test https://github.com/janosh/pdf-compressor/issues/9
         main([f".{os.path.sep}dummy.pdf"])
 
     finally:  # ensures clean up code runs even if main() crashed

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -48,7 +48,7 @@ def test_main_in_place():
 
     finally:
         if os.path.isfile(backup_path):
-            os.rename(backup_path, pdf_path)
+            os.replace(backup_path, pdf_path)
 
 
 def test_main_multi_file():


### PR DESCRIPTION
Closes #9.

Windows/Powershell understands `/` in filenames instead of `\` which iLovePDF API doesn't appear to handle well ([see comment](https://github.com/janosh/pdf-compressor/issues/9#issuecomment-1028933925)). Easiest fix seems to be to replace `\` with `/` in all input file paths, even on Windows.