### PR TITLE
Ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,27 +6,16 @@ default_stages: [commit]
 default_install_hook_types: [pre-commit, commit-msg]
 
 repos:
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.248
     hooks:
-      - id: isort
+      - id: ruff
+        args: [--fix]
 
   - repo: https://github.com/psf/black
     rev: 23.1.0
     hooks:
       - id: black
-
-  - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
-    hooks:
-      - id: flake8
-        additional_dependencies: [flake8-bugbear]
-
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.1
-    hooks:
-      - id: pyupgrade
-        args: [--py38-plus]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.991
@@ -50,25 +39,3 @@ repos:
     hooks:
       - id: codespell
         stages: [commit, commit-msg]
-
-  - repo: https://github.com/PyCQA/autoflake
-    rev: v2.0.1
-    hooks:
-      - id: autoflake
-
-  - repo: https://github.com/PyCQA/pydocstyle
-    rev: 6.3.0
-    hooks:
-      - id: pydocstyle
-        exclude: tests
-
-  - repo: https://github.com/PyCQA/docformatter
-    rev: v1.6.0.rc1
-    hooks:
-      - id: docformatter
-
-  - repo: https://github.com/jendrikseipp/vulture
-    rev: v2.7
-    hooks:
-      - id: vulture
-        args: [.]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
       - id: black
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.991
+    rev: v1.0.1
     hooks:
       - id: mypy
         additional_dependencies: [types-requests]

--- a/pdf_compressor/ilovepdf.py
+++ b/pdf_compressor/ilovepdf.py
@@ -120,6 +120,7 @@ class Task(ILovePDF):
                 https://developer.ilovepdf.com/docs/api-reference#process.
             verbose (bool, optional): Whether to print progress messages while uploading
                 and processing files. Defaults to False.
+            **kwargs: Additional keyword arguments to pass to ILovePDF.__init__().
         """
         super().__init__(public_key, **kwargs)
 
@@ -309,6 +310,7 @@ class Compress(Task):
                 https://developer.ilovepdf.com/signup.
             compression_level (str, optional): How hard to squeeze the file size.
                 'extreme' noticeably degrades image quality. Defaults to 'recommended'.
+            **kwargs: Additional keyword arguments to pass to Task.__init__().
         """
         super().__init__(public_key, tool="compress", **kwargs)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,15 +37,6 @@ find = { include = ["pdf_compressor"] }
 [tool.distutils.bdist_wheel]
 universal = true
 
-[tool.distutils.isort]
-profile = "black"
-
-[tool.flake8]
-max-line-length = "88"
-max-complexity = "16"
-ignore = "E731, E203"
-per-file-ignores = "\n__init__.py: F401"
-
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-p no:warnings"
@@ -59,19 +50,39 @@ warn_redundant_casts = true
 warn_unused_ignores = true
 no_implicit_optional = false
 
-[tool.autoflake]
-in-place = "true"
-remove-unused-variables = "true"
-remove-all-unused-imports = "true"
-expand-star-imports = "true"
-ignore-init-module-imports = "true"
+[tool.ruff]
+target-version = "py38"
+select = [
+    "B",   # flake8-bugbear
+    "D",   # pydocstyle
+    "E",   # pycodestyle
+    "ERA", # flake8-eradicate
+    "F",   # pyflakes
+    "I",   # isort
+    "PLE", # pylint error
+    "PLW", # pylint warning
+    "PYI", # flakes8-pyi
+    "Q",   # flake8-quotes
+    "SIM", # flake8-simplify
+    "TID", # tidy imports
+    "UP",  # pyupgrade
+    "W",   # pycodestyle
+    "YTT", # flake8-2020
+]
+ignore = [
+    "B019",    # functools.lru_cache on methods can lead to memory leaks
+    "B023",    # Function definition does not bind loop variable
+    "B904",    # Within an except clause, raise exceptions with ...
+    "D100",    # Missing docstring in public module
+    "D104",    # Missing docstring in public package
+    "D205",    # 1 blank line required between summary line and description
+    "E741",    # tmp: we should fix all ambiguous variable names
+    "PLR2004", # Magic number
+    "PLW0120", # tmp: awaiting bug fix https://github.com/charliermarsh/ruff/issues/3019
+    "SIM105",  # Use contextlib.suppress(FileNotFoundError) instead of try-except-pass
+]
+pydocstyle.convention = "google"
 
-[tool.pydocstyle]
-convention = "google"
-add-ignore = "D100,D104,D107,D205,D415"
-
-[tool.docformatter]
-recursive = "true"
-wrap-summaries = "88"
-wrap-descriptions = "88"
-close-quotes-on-newline = "true"
+[tool.ruff.per-file-ignores]
+"__init__.py" = ["F401"]
+"tests/*" = ["D103"]


### PR DESCRIPTION
Replace pre-commit hooks `flake8` `pyupgrade` `autoflake` `pydocstyle` `docformatter` `vulture` with `ruff`.