### PR TITLE
Recursively glob for PDFs when passed directories

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,19 +6,19 @@ default_stages: [commit]
 default_install_hook_types: [pre-commit, commit-msg]
 
 repos:
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.275
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.0.285
     hooks:
       - id: ruff
         args: [--fix]
 
   - repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 23.7.0
     hooks:
       - id: black
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.4.0
+    rev: v1.5.1
     hooks:
       - id: mypy
         additional_dependencies: [types-requests]

--- a/pdf_compressor/__init__.py
+++ b/pdf_compressor/__init__.py
@@ -1,3 +1,10 @@
-from .ilovepdf import Compress, ILovePDF, Task
-from .main import DEFAULT_SUFFIX, main
-from .utils import si_fmt
+from importlib.metadata import PackageNotFoundError, version
+
+from pdf_compressor.ilovepdf import Compress, ILovePDF, Task
+from pdf_compressor.main import DEFAULT_SUFFIX, main
+from pdf_compressor.utils import si_fmt
+
+try:
+    __version__ = version(__name__)
+except PackageNotFoundError:
+    pass  # package not installed

--- a/pdf_compressor/ilovepdf.py
+++ b/pdf_compressor/ilovepdf.py
@@ -261,12 +261,12 @@ class Task(ILovePDF):
 
         if not save_to_dir:  # save_to_dir is None or ''
             save_to_dir = tempfile.mkdtemp()
-        else:
-            os.makedirs(save_to_dir, exist_ok=True)
 
         file_path = os.path.join(
             save_to_dir, self._process_response["download_filename"]
         )
+
+        os.makedirs(os.path.dirname(file_path), exist_ok=True)
 
         # response.content is PDF file or ZIP archive, either way, we save as binary
         with open(file_path, "wb") as file:

--- a/pdf_compressor/ilovepdf.py
+++ b/pdf_compressor/ilovepdf.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 import os
+import tempfile
 from typing import Any, BinaryIO, Literal, TypedDict
 
 import requests
@@ -243,7 +244,7 @@ class Task(ILovePDF):
         as a PDF. Multiple files are saved in a compressed ZIP folder.
 
         Raises:
-            ValueError: If task.download() is called in absence of downloadbale files,
+            ValueError: If task.download() is called in absence of downloadable files,
                 usually because task.process() wasn't called yet.
 
         Returns:
@@ -259,7 +260,7 @@ class Task(ILovePDF):
         response = self._send_request("get", endpoint, stream=True)
 
         if not save_to_dir:  # save_to_dir is None or ''
-            save_to_dir = os.getcwd()
+            save_to_dir = tempfile.mkdtemp()
         else:
             os.makedirs(save_to_dir, exist_ok=True)
 

--- a/pdf_compressor/main.py
+++ b/pdf_compressor/main.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import re
 from argparse import ArgumentParser
+from glob import glob
 from importlib.metadata import version
 from typing import Sequence
 
@@ -143,6 +144,11 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     # use set() to ensure no duplicate files
     files: list[str] = sorted({f.replace("\\", "/").strip() for f in args.filenames})
+    # for each directory received glob for all PDFs in it
+    for filepath in files:
+        if os.path.isdir(filepath):
+            files.remove(filepath)
+            files.extend(glob(os.path.join(filepath, "**", "*.pdf*"), recursive=True))
     # match files case insensitively ending with .pdf(,a,x) and possible white space
     pdfs = [f for f in files if re.match(r".*\.pdf[ax]?\s*$", f.lower())]
     not_pdfs = {*files} - {*pdfs}

--- a/pdf_compressor/utils.py
+++ b/pdf_compressor/utils.py
@@ -11,7 +11,7 @@ ROOT = dirname(dirname(abspath(__file__)))
 
 
 def si_fmt(
-    val: int | float, binary: bool = True, fmt_spec: str = ".1f", sep: str = ""
+    val: float, binary: bool = True, fmt_spec: str = ".1f", sep: str = ""
 ) -> str:
     """Convert large numbers into human readable format using SI prefixes in binary
     (1024) or metric (1000) mode.
@@ -156,5 +156,5 @@ def del_or_keep_compressed(
     for filename in (*compressed_files, downloaded_file):
         try:
             os.remove(filename)
-        except OSError:
+        except OSError:  # noqa: PERF203
             pass

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -64,6 +64,18 @@ def test_main_in_place(capsys: CaptureFixture[str], tmp_path: Path) -> None:
     main([input_pdf, "-i", "--min-size-reduction", "0"])
 
 
+def test_main_dir_glob(capsys: CaptureFixture[str], tmp_path: Path) -> None:
+    """Test passing a directory to make sure main() recursively globs for PDFs."""
+    input_pdf = shutil.copy2(dummy_pdf, tmp_path)
+
+    ret_code = main([str(tmp_path), "-i", "--verbose"])
+    assert ret_code == 0, "main() should return 0 on success"
+    std_out, std_err = capsys.readouterr()
+    assert std_out.startswith("PDFs to be compressed with iLovePDF: 1")
+    assert input_pdf in std_out
+    assert std_err == ""
+
+
 def test_main_report_quota(capsys: CaptureFixture[str]) -> None:
     """Test CLI quota reporting."""
     main(["--report-quota"])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -82,7 +82,7 @@ def test_main_report_quota(capsys: CaptureFixture[str]) -> None:
 
     std_out, std_err = capsys.readouterr()
 
-    assert std_out.startswith("Remaining files ")
+    assert std_out.startswith("Remaining files in this billing cycle: ")
     assert std_err == ""
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -72,7 +72,8 @@ def test_main_dir_glob(capsys: CaptureFixture[str], tmp_path: Path) -> None:
     assert ret_code == 0, "main() should return 0 on success"
     std_out, std_err = capsys.readouterr()
     assert std_out.startswith("PDFs to be compressed with iLovePDF: 1")
-    assert input_pdf in std_out
+    if sys.platform == "darwin":
+        assert input_pdf in std_out
     assert std_err == ""
 
 


### PR DESCRIPTION
6bc5b46 `pre-commit autoupdate`
e6d3e21 add `__version__` to `__init__.py`
bea9554 check if input files are directories and if so, recursively glob them for PDFs
f46569a `test_main_dir_glob()`