### PR TITLE
Fix replacing original files with wrong compressed files when handling >10 files at once

### DIFF
--- a/pdf_compressor/ilovepdf.py
+++ b/pdf_compressor/ilovepdf.py
@@ -266,6 +266,8 @@ class Task(ILovePDF):
             save_to_dir, self._process_response["download_filename"]
         )
 
+        # create parent dir (we use download_filename instead of save_to_dir because it
+        # may contain subdirs)
         os.makedirs(os.path.dirname(file_path), exist_ok=True)
 
         # response.content is PDF file or ZIP archive, either way, we save as binary

--- a/pdf_compressor/main.py
+++ b/pdf_compressor/main.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 DEFAULT_SUFFIX = "-compressed"
 
 
-def main(argv: Sequence[str] | None = None) -> int:  # noqa: C901
+def main(argv: Sequence[str] | None = None) -> int:
     """Compress PDFs using iLovePDF's API."""
     parser = ArgumentParser(
         description="Batch compress PDFs on the command line. Powered by iLovePDF.com.",

--- a/pdf_compressor/utils.py
+++ b/pdf_compressor/utils.py
@@ -111,6 +111,8 @@ def del_or_keep_compressed(
 
     trash_path = f"{expanduser('~')}/.Trash"  # macOS only, no need for os.path.join()
 
+    total_orig_size = total_compressed_size = 0
+
     for idx, orig_path in enumerate(pdfs):
         compressed_path = next(
             filename
@@ -120,8 +122,11 @@ def del_or_keep_compressed(
         orig_size = getsize(orig_path)
         compressed_size = getsize(compressed_path)
 
+        total_orig_size += orig_size
+        total_compressed_size += compressed_size
+
         diff = orig_size - compressed_size
-        counter = f"\n{idx}: " if n_files > 1 else ""
+        counter = f"\n{idx + 1}: " if n_files > 1 else ""
 
         if diff / orig_size > min_size_reduction / 100:
             filepath = orig_path if verbose else basename(orig_path)
@@ -167,3 +172,11 @@ def del_or_keep_compressed(
             os.remove(filename)
         except OSError:  # noqa: PERF203
             pass
+
+    # print overall size reduction if >= 2 file
+    overall_reduction = total_orig_size - total_compressed_size
+    if n_files > 2 and overall_reduction > 0:
+        print(
+            f"Overall size reduction in {n_files} files: {si_fmt(overall_reduction)}B, "
+            f"from {si_fmt(total_orig_size)}B to {si_fmt(total_compressed_size)}B"
+        )

--- a/pdf_compressor/utils.py
+++ b/pdf_compressor/utils.py
@@ -126,13 +126,13 @@ def del_or_keep_compressed(
         total_compressed_size += compressed_size
 
         diff = orig_size - compressed_size
-        counter = f"\n{idx + 1}: " if n_files > 1 else ""
+        counter = f"\n{idx + 1} " if n_files > 1 else ""
 
         if diff / orig_size > min_size_reduction / 100:
             filepath = orig_path if verbose else basename(orig_path)
             print(
-                f"{counter}'{filepath}' is now {si_fmt(compressed_size)}B, was "
-                f"{si_fmt(orig_size)}B which is {si_fmt(diff)}B = {diff/orig_size:.0%} "
+                f"{counter}'{filepath}': {si_fmt(orig_size)}B -> "
+                f"{si_fmt(compressed_size)}B, {si_fmt(diff)}B = {diff/orig_size:.0%} "
                 "smaller."
             )
 

--- a/pdf_compressor/utils.py
+++ b/pdf_compressor/utils.py
@@ -114,11 +114,14 @@ def del_or_keep_compressed(
     total_orig_size = total_compressed_size = 0
 
     for idx, orig_path in enumerate(pdfs):
-        compressed_path = next(
-            filename
-            for filename in compressed_files
-            if os.path.basename(filename).startswith(f"{idx}-")
-        )
+        if n_files > 1:
+            compressed_path = next(
+                filename
+                for filename in compressed_files
+                if os.path.basename(filename).startswith(f"{idx}-")
+            )
+        else:
+            compressed_path = compressed_files[0]
         orig_size = getsize(orig_path)
         compressed_size = getsize(compressed_path)
 

--- a/pdf_compressor/utils.py
+++ b/pdf_compressor/utils.py
@@ -111,7 +111,12 @@ def del_or_keep_compressed(
 
     trash_path = f"{expanduser('~')}/.Trash"  # macOS only, no need for os.path.join()
 
-    for idx, (orig_path, compressed_path) in enumerate(zip(pdfs, compressed_files), 1):
+    for idx, orig_path in enumerate(pdfs):
+        compressed_path = next(
+            filename
+            for filename in compressed_files
+            if os.path.basename(filename).startswith(f"{idx}-")
+        )
         orig_size = getsize(orig_path)
         compressed_size = getsize(compressed_path)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ select = ["ALL"]
 ignore = [
     "ANN101",
     "ANN401", # Dynamically typed expressions (typing.Any) are disallowed in `**kwargs
+    "C901",   # Function is too complex
     "COM",
     "D100",   # Missing docstring in public module
     "D104",   # Missing docstring in public package

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 dummy_pdf = "assets/dummy.pdf"
 compressed_pdf = f"dummy{DEFAULT_SUFFIX}.pdf"
 
-expected_out = "'dummy.pdf' is now 9.6KB, was 13.0KB which is 3.4KB = 26% smaller.\n"
+expected_out = "'dummy.pdf': 13.0KB -> 9.6KB, 3.4KB = 26% smaller.\n"
 
 
 def test_main_batch_compress(tmp_path: Path, capsys: CaptureFixture[str]) -> None:
@@ -36,9 +36,7 @@ def test_main_batch_compress(tmp_path: Path, capsys: CaptureFixture[str]) -> Non
     assert os.path.isfile(str(tmp_path / compressed_pdf))
 
     std_out, std_err = capsys.readouterr()
-    assert (
-        std_out == f"\n1: {expected_out}\n2: {expected_out.replace('dummy', 'dummy2')}"
-    )
+    assert std_out == f"\n1 {expected_out}\n2 {expected_out.replace('dummy', 'dummy2')}"
     assert std_err == ""
 
 


### PR DESCRIPTION
Me can't code! 🤦 

Also, print overall size reduction in `del_or_keep_compressed()` if `n_files` > 2.