### PR TITLE
Split `main()` into `compress()` and leaner `main()` function

### DIFF
--- a/pdf_compressor/__init__.py
+++ b/pdf_compressor/__init__.py
@@ -1,7 +1,7 @@
 from importlib.metadata import PackageNotFoundError, version
 
 from pdf_compressor.ilovepdf import Compress, ILovePDF, Task
-from pdf_compressor.main import DEFAULT_SUFFIX, main
+from pdf_compressor.main import DEFAULT_SUFFIX, compress, main
 from pdf_compressor.utils import si_fmt
 
 try:

--- a/pdf_compressor/utils.py
+++ b/pdf_compressor/utils.py
@@ -62,16 +62,14 @@ def load_dotenv(filepath: str | None = None) -> None:
     if filepath is None:
         filepath = os.path.join(f"{ROOT}", ".env")
 
-    if not isfile(filepath) or getsize(filepath) == 0:
-        return
+    if isfile(filepath):
+        with open(filepath, encoding="utf8") as dotenv:
+            for line in dotenv:
+                if line.startswith("#"):
+                    continue
 
-    with open(filepath, encoding="utf8") as dotenv:
-        for line in dotenv:
-            if line.startswith("#"):
-                continue
-
-            key, val = line.replace("\n", "").split("=")
-            os.environ[key] = val
+                key, val = line.replace("\n", "").split("=")
+                os.environ[key] = val
 
 
 def del_or_keep_compressed(

--- a/pdf_compressor/utils.py
+++ b/pdf_compressor/utils.py
@@ -13,9 +13,7 @@ if TYPE_CHECKING:
 ROOT = dirname(dirname(abspath(__file__)))
 
 
-def si_fmt(
-    val: float, binary: bool = True, fmt_spec: str = ".1f", sep: str = ""
-) -> str:
+def si_fmt(val: float, binary: bool = True, fmt: str = ".1f", sep: str = "") -> str:
     """Convert large numbers into human readable format using SI prefixes in binary
     (1024) or metric (1000) mode.
 
@@ -25,7 +23,7 @@ def si_fmt(
         val (int | float): Some numerical value to format.
         binary (bool, optional): If True, scaling factor is 2^10 = 1024 else 1000.
             Defaults to True.
-        fmt_spec (str): f-string format specifier. Configure precision and left/right
+        fmt (str): f-string format specifier. Configure precision and left/right
             padding in returned string. Defaults to ".1f". Can be used to ensure leading
             or trailing whitespace for shorter numbers. Ex.1: ">10.2f" has 2 decimal
             places and is at least 10 characters long with leading spaces if necessary.
@@ -52,7 +50,7 @@ def si_fmt(
                 break
             val *= factor
 
-    return f"{val:{fmt_spec}}{sep}{_scale}"
+    return f"{val:{fmt}}{sep}{_scale}"
 
 
 def load_dotenv(filepath: str | None = None) -> None:

--- a/pdf_compressor/utils.py
+++ b/pdf_compressor/utils.py
@@ -151,7 +151,12 @@ def del_or_keep_compressed(
                     print("Old file moved to trash.")
                     orig_file_name = os.path.split(orig_path)[1]
 
-                    os.rename(orig_path, f"{expanduser('~')}/.Trash/{orig_file_name}")
+                    trash_path = f"{expanduser('~')}/.Trash/{orig_file_name}"
+                    if isfile(trash_path):  # if file with same name already in trash,
+                        # delete it to avoid PermissionError: [Errno 1] Operation not
+                        # permitted
+                        os.remove(trash_path)
+                    os.rename(orig_path, trash_path)
                 else:
                     print("Old file deleted.")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ Package = "https://pypi.org/project/pdf-compressor"
 
 [project.optional-dependencies]
 test = ["pytest", "pytest-cov"]
-stats = ["pandas"]              # needed for --write-stats option
+stats = ["pandas"]              # needed for --write-stats-path option
 
 [project.scripts]
 pdf-compressor = "pdf_compressor:main"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -11,6 +11,7 @@ import pytest
 from pytest import CaptureFixture
 
 from pdf_compressor import DEFAULT_SUFFIX, main
+from pdf_compressor.main import API_KEY_KEY
 from pdf_compressor.utils import load_dotenv
 
 if TYPE_CHECKING:
@@ -32,7 +33,9 @@ def test_main_batch_compress(tmp_path: Path, capsys: CaptureFixture[str]) -> Non
 
     # add input_path twice to test how we handle duplicate input files
     stats_path = f"{tmp_path}/stats.csv"
-    ret_code = main([input_path, input_path, input_path_2, "--write-stats", stats_path])
+    ret_code = main(
+        [input_path, input_path, input_path_2, "--write-stats-path", stats_path]
+    )
     assert ret_code == 0, f"expected main() exit code to be 0, got {ret_code}"
 
     # check stats file was written and has expected content
@@ -104,7 +107,7 @@ def test_main_set_api_key() -> None:
     """Test CLI setting iLovePDF public API key."""
     load_dotenv()
 
-    api_key = os.environ["ILOVEPDF_PUBLIC_KEY"]  # save API key to reset it later
+    api_key = os.environ[API_KEY_KEY]  # save API key to reset it later
 
     with pytest.raises(ValueError, match="invalid API key"):
         main(["--set-api-key", "foo"])
@@ -113,7 +116,7 @@ def test_main_set_api_key() -> None:
 
     load_dotenv()
 
-    assert os.environ["ILOVEPDF_PUBLIC_KEY"] == "project_public_foobar"
+    assert os.environ[API_KEY_KEY] == "project_public_foobar"
 
     main(["--set-api-key", api_key])  # restore previous value
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,8 +6,8 @@ from pdf_compressor.utils import si_fmt
 def test_si_fmt() -> None:
     assert si_fmt(123456) == "120.6K"
 
-    assert si_fmt(12345678, fmt_spec=">6.2f", sep=" ") == " 11.77 M"
+    assert si_fmt(12345678, fmt=">6.2f", sep=" ") == " 11.77 M"
 
-    assert si_fmt(0.00123, fmt_spec=".3g", binary=False) == "1.23m"
+    assert si_fmt(0.00123, fmt=".3g", binary=False) == "1.23m"
 
-    assert si_fmt(0.00000123, fmt_spec="5.1f", sep=" ") == "  1.3 μ"
+    assert si_fmt(0.00000123, fmt="5.1f", sep=" ") == "  1.3 μ"


### PR DESCRIPTION
`compress()` can be used directly from external python and `main()` now solely responsible for CLI.

Also breaking: rename `--write-stats(''->-path)` CLI option