### PR TITLE
Add CLI flags `--password` and `--outdir`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ on:
     paths: ["**/*.py", ".github/workflows/test.yml"]
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   tests:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,14 +7,14 @@ default_install_hook_types: [pre-commit, commit-msg]
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.8
+    rev: v0.5.3
     hooks:
       - id: ruff
         args: [--fix]
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.10.0
+    rev: v1.10.1
     hooks:
       - id: mypy
         additional_dependencies: [types-requests]

--- a/pdf_compressor/ilovepdf.py
+++ b/pdf_compressor/ilovepdf.py
@@ -271,7 +271,7 @@ class Task(ILovePDF):
 
         response = self._send_request("get", endpoint, stream=True)
 
-        if not save_to_dir:  # save_to_dir is None or ''
+        if save_to_dir is None:  # save_to_dir is None or ''
             save_to_dir = tempfile.mkdtemp()
 
         file_path = os.path.join(

--- a/pdf_compressor/ilovepdf.py
+++ b/pdf_compressor/ilovepdf.py
@@ -271,7 +271,7 @@ class Task(ILovePDF):
 
         response = self._send_request("get", endpoint, stream=True)
 
-        if save_to_dir is None:  # save_to_dir is None or ''
+        if not save_to_dir:  # save_to_dir is None or ''
             save_to_dir = tempfile.mkdtemp()
 
         file_path = os.path.join(

--- a/pdf_compressor/ilovepdf.py
+++ b/pdf_compressor/ilovepdf.py
@@ -109,7 +109,13 @@ class Task(ILovePDF):
     """
 
     def __init__(
-        self, public_key: str, tool: str, *, verbose: bool = False, **kwargs: Any
+        self,
+        public_key: str,
+        tool: str,
+        *,
+        verbose: bool = False,
+        password: str = "",
+        **kwargs: Any,
     ) -> None:
         """Creates a new task object to interact with the API.
 
@@ -122,6 +128,8 @@ class Task(ILovePDF):
                 https://developer.ilovepdf.com/docs/api-reference#process.
             verbose (bool, optional): Whether to print progress messages while uploading
                 and processing files. Defaults to False.
+            password (str, optional): Password to open PDFs in case they have one.
+                Defaults to "".
             **kwargs: Additional keyword arguments to pass to ILovePDF.__init__().
         """
         super().__init__(public_key, **kwargs)
@@ -132,6 +140,7 @@ class Task(ILovePDF):
 
         self.verbose = verbose
         self.tool = tool
+        self.password = password
 
         # API options https://developer.ilovepdf.com/docs/api-reference#process
         # placeholders like {app}, {n}, {filename} in output/packaged_filename will be
@@ -221,6 +230,7 @@ class Task(ILovePDF):
         for idx, (filename, server_filename) in enumerate(self.files.items()):
             payload[f"files[{idx}][filename]"] = filename
             payload[f"files[{idx}][server_filename]"] = server_filename
+            payload[f"files[{idx}][password]"] = self.password
 
         response: ProcessResponse = self._send_request(
             "post", "process", payload=payload

--- a/pdf_compressor/main.py
+++ b/pdf_compressor/main.py
@@ -37,6 +37,13 @@ def main(argv: Sequence[str] | None = None) -> int:
         "immediately afterwards ignoring all other flags.",
     )
 
+    parser.add_argument(
+        "--password",
+        type=str,
+        default="",
+        help="Password for protected PDF files. All files will use the same password. "
+        "Protected PDFs with different passwords must be compressed one by one.",
+    )
     group = parser.add_mutually_exclusive_group()
 
     group.add_argument(
@@ -166,6 +173,7 @@ def compress(
     on_no_files: str = "ignore",
     on_bad_files: str = "error",
     write_stats_path: str = "",
+    password: str = "",
     **kwargs: Any,  # noqa: ARG001
 ) -> int:
     """Compress PDFs using iLovePDF's API.
@@ -186,6 +194,9 @@ def compress(
         write_stats_path (str): File path to write a CSV, Excel or other pandas
             supported file format with original vs compressed file sizes and actions
             taken on each input file
+        password (str): Password to open PDFs in case they have one. Defaults to "".
+            TODO There's currently no way of passing different passwords for different
+            files. PDFs with different passwords must be compressed one by one.
         **kwargs: Additional keywords are ignored.
 
     Returns:
@@ -237,7 +248,9 @@ def compress(
             raise ValueError("No input files provided")
         return 0
 
-    task = Compress(api_key, compression_level=compression_level, debug=debug)
+    task = Compress(
+        api_key, compression_level=compression_level, debug=debug, password=password
+    )
     task.verbose = verbose
 
     for pdf in pdfs:

--- a/pdf_compressor/main.py
+++ b/pdf_compressor/main.py
@@ -52,6 +52,14 @@ def main(argv: Sequence[str] | None = None) -> int:
         action="store_true",
         help="Whether to compress PDFs in place. Defaults to False.",
     )
+    parser.add_argument(
+        "-o",
+        "--outdir",
+        type=str,
+        default="",
+        help="Output directory for compressed PDFs. Defaults to the current working "
+        "directory.",
+    )
 
     group.add_argument(
         "-s",
@@ -165,6 +173,7 @@ def compress(
     filenames: Sequence[str],
     *,
     inplace: bool = False,
+    outdir: str = "",
     suffix: str = DEFAULT_SUFFIX,
     compression_level: str = "recommended",
     min_size_reduction: int | None = None,
@@ -181,6 +190,8 @@ def compress(
     Args:
         filenames (list[str]): List of PDF files to compress.
         inplace (bool): Whether to compress PDFs in place.
+        outdir (str): Output directory for compressed PDFs. Defaults to the current
+            working directory.
         suffix (str): String to append to the filename of compressed PDFs.
         compression_level (str): How hard to squeeze the file size.
         min_size_reduction (int): How much compressed files need to be smaller than
@@ -261,7 +272,7 @@ def compress(
 
     task.process()
 
-    downloaded_file = task.download()
+    downloaded_file = task.download(save_to_dir=outdir)
 
     task.delete_current_task()
 

--- a/pdf_compressor/utils.py
+++ b/pdf_compressor/utils.py
@@ -103,7 +103,7 @@ def del_or_keep_compressed(
     """
     if (n_files := len(pdfs)) == 1:
         compressed_files = [downloaded_file]
-    else:
+    else:  # if multiple files were uploaded, downloaded_file is a ZIP archive
         with ZipFile(downloaded_file) as archive:
             # sort compressed_files since pdfs were also sorted
             compressed_files = sorted(archive.namelist())


### PR DESCRIPTION
to control final location for compressed PDFs and allow compressing password-protected PDFs